### PR TITLE
Instead of overriding initialize use the option macros, this allows you to use a lambda to override the defaults per request

### DIFF
--- a/lib/omniauth/strategies/google.rb
+++ b/lib/omniauth/strategies/google.rb
@@ -8,29 +8,23 @@ module OmniAuth
     # Usage:
     #    use OmniAuth::Strategies::Google, 'consumerkey', 'consumersecret'
     class Google < OmniAuth::Strategies::OAuth
-      def initialize(app, consumer_key=nil, consumer_secret=nil, options={}, &block)
-        client_options = {
-          :access_token_path => '/accounts/OAuthGetAccessToken',
-          :authorize_path => '/accounts/OAuthAuthorizeToken',
-          :request_token_path => '/accounts/OAuthGetRequestToken',
-          :site => 'https://www.google.com',
-        }
-        google_contacts_auth = 'www.google.com/m8/feeds'
-        options[:scope] ||= "https://#{google_contacts_auth}"
-        options[:scope] << " https://#{google_contacts_auth}" unless options[:scope] =~ %r[http[s]?:\/\/#{google_contacts_auth}]
-        options[:client_options] = client_options
+      option :client_options, {
+        :access_token_path => '/accounts/OAuthGetAccessToken',
+        :authorize_path => '/accounts/OAuthAuthorizeToken',
+        :request_token_path => '/accounts/OAuthGetRequestToken',
+        :site => 'https://www.google.com'
+      }
 
-        super(app, consumer_key, consumer_secret, options, &block)
-      end
+      option :scope, "https://www.google.com/m8/feeds"
 
       uid do
         user_info['uid']
       end
-      
+
       info do
         user_info
       end
-      
+
       extra do
         { 'user_hash' => user_hash }
       end
@@ -63,20 +57,20 @@ module OmniAuth
       def request_phase
         request_options = {:scope => options[:scope]}
         request_options.merge!(options[:authorize_params])
-      
+
         request_token = consumer.get_request_token({:oauth_callback => callback_url}, request_options)
         session['oauth'] ||= {}
         session['oauth'][name.to_s] = {'callback_confirmed' => request_token.callback_confirmed?, 'request_token' => request_token.token, 'request_secret' => request_token.secret}
         r = Rack::Response.new
-      
+
         if request_token.callback_confirmed?
           r.redirect(request_token.authorize_url)
         else
           r.redirect(request_token.authorize_url(:oauth_callback => callback_url))
         end
-      
+
         r.finish
-      
+
         rescue ::Timeout::Error => e
           fail!(:timeout, e)
         rescue ::Net::HTTPFatalError, ::OpenSSL::SSL::SSLError => e

--- a/omniauth-google.gemspec
+++ b/omniauth-google.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<omniauth>, ["~> 1.0.0"])
+      s.add_runtime_dependency(%q<omniauth>, ["~> 1.1.0"])
       s.add_runtime_dependency(%q<omniauth-oauth>, [">= 0"])
       s.add_runtime_dependency(%q<multi_json>, [">= 0"])
       s.add_development_dependency(%q<bundler>, [">= 0"])
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rspec>, [">= 0"])
       s.add_development_dependency(%q<webmock>, [">= 0"])
     else
-      s.add_dependency(%q<omniauth>, ["~> 1.0.0"])
+      s.add_dependency(%q<omniauth>, ["~> 1.1.0"])
       s.add_dependency(%q<omniauth-oauth>, [">= 0"])
       s.add_dependency(%q<multi_json>, [">= 0"])
       s.add_dependency(%q<bundler>, [">= 0"])
@@ -60,7 +60,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<webmock>, [">= 0"])
     end
   else
-    s.add_dependency(%q<omniauth>, ["~> 1.0.0"])
+    s.add_dependency(%q<omniauth>, ["~> 1.1.0"])
     s.add_dependency(%q<omniauth-oauth>, [">= 0"])
     s.add_dependency(%q<multi_json>, [">= 0"])
     s.add_dependency(%q<bundler>, [">= 0"])


### PR DESCRIPTION
The gain of this change is that you can use a lambda on each requests as described on the OmniAuth wiki: https://github.com/intridea/omniauth/wiki/Dynamic-Providers

The one thing that gets lost in this change is the ability to set the scope without the Google contacts URL in it, is this acceptable?
