### PR TITLE
Made userinfo.email and userinfo.profile scopes the default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem 'omniauth', "~> 1.0.0"
+gem 'omniauth', "~> 1.0"
 gem 'omniauth-oauth'
 gem 'multi_json'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem 'omniauth', "~> 1.0.0"
+gem 'omniauth', "~> 1"
 gem 'omniauth-oauth'
 gem 'multi_json'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem 'omniauth', "~> 1"
+gem 'omniauth', "~> 1.0.0"
 gem 'omniauth-oauth'
 gem 'multi_json'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ DEPENDENCIES
   bundler
   jeweler
   multi_json
-  omniauth (~> 1.0.0)
+  omniauth (~> 1.0)
   omniauth-oauth
   rack-test
   rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ DEPENDENCIES
   bundler
   jeweler
   multi_json
-  omniauth (~> 1.0.0)
+  omniauth (~> 1)
   omniauth-oauth
   rack-test
   rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ DEPENDENCIES
   bundler
   jeweler
   multi_json
-  omniauth (~> 1)
+  omniauth (~> 1.0.0)
   omniauth-oauth
   rack-test
   rspec

--- a/omniauth-google.gemspec
+++ b/omniauth-google.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<omniauth>, ["~> 1.0.0"])
+      s.add_runtime_dependency(%q<omniauth>, ["~> 1.0"])
       s.add_runtime_dependency(%q<omniauth-oauth>, [">= 0"])
       s.add_runtime_dependency(%q<multi_json>, [">= 0"])
       s.add_development_dependency(%q<bundler>, [">= 0"])
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rspec>, [">= 0"])
       s.add_development_dependency(%q<webmock>, [">= 0"])
     else
-      s.add_dependency(%q<omniauth>, ["~> 1.0.0"])
+      s.add_dependency(%q<omniauth>, ["~> 1.0"])
       s.add_dependency(%q<omniauth-oauth>, [">= 0"])
       s.add_dependency(%q<multi_json>, [">= 0"])
       s.add_dependency(%q<bundler>, [">= 0"])
@@ -60,7 +60,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<webmock>, [">= 0"])
     end
   else
-    s.add_dependency(%q<omniauth>, ["~> 1.0.0"])
+    s.add_dependency(%q<omniauth>, ["~> 1.0"])
     s.add_dependency(%q<omniauth-oauth>, [">= 0"])
     s.add_dependency(%q<multi_json>, [">= 0"])
     s.add_dependency(%q<bundler>, [">= 0"])


### PR DESCRIPTION
You no longer need to request the Google Contacts scope as a workaround for getting a user's profile information - by default the more granular but sufficient userinfo.email and userinfo.profile scopes are requested.
